### PR TITLE
Update response content type in /files/{file_id}/content endpoint

### DIFF
--- a/docs/spec/openapi.yaml
+++ b/docs/spec/openapi.yaml
@@ -1694,7 +1694,7 @@ paths:
                 "200":
                     description: OK
                     content:
-                        application/json:
+                        application/octet-stream:
                             schema:
                                 type: string
             x-oaiMeta:

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -37,12 +37,12 @@ This document records the sanitation done on top of the official OpenAPI specifi
 
    - **Reasons**: The response does not include the code, message, and param, causing an error of missing required fields when converting.
 
-4. **Changed the responce content type in /files/{file_id}/content end point**
-   - **Original**: The response content type of the /files/{file_id}/content endpoint was originally application/json.
+4. **Changed the response content type in `/files/{file_id}/content` endpoint**
+   - **Original**: The response content type of the `/files/{file_id}/content` endpoint was originally `application/json`.
 
-   - **Updated**: The content type has been changed to application/octet-stream.
+   - **Updated**: The content type has been changed to `application/octet-stream`.
 
-   - **Reasons**: The server's actual response content type was application/octet-stream.
+   - **Reasons**: The server's actual response content type was `application/octet-stream`.
 
 ## OpenAPI cli command
 

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -37,6 +37,13 @@ This document records the sanitation done on top of the official OpenAPI specifi
 
    - **Reasons**: The response does not include the code, message, and param, causing an error of missing required fields when converting.
 
+4. **Changed the responce content type in /files/{file_id}/content end point**
+   - **Original**: The response content type of the /files/{file_id}/content endpoint was originally application/json.
+
+   - **Updated**: The content type has been changed to application/octet-stream.
+
+   - **Reasons**: The server's actual response content type was application/octet-stream.
+
 ## OpenAPI cli command
 
 The following command was used to generate the Ballerina client from the OpenAPI specification. The command should be executed from the repository root directory.


### PR DESCRIPTION
## Purpose

**Changed the responce content type in /files/{file_id}/content end point**
   - **Original**: The response content type of the /files/{file_id}/content endpoint was originally application/json.

   - **Updated**: The content type has been changed to application/octet-stream.

   - **Reasons**: The server's actual response content type was application/octet-stream.
