### PR TITLE
Clarify Overview so the Central summary distinguishes openai.finetunes

### DIFF
--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -1,9 +1,7 @@
 
 ## Overview
 
-[OpenAI](https://openai.com/) offers powerful AI models for tasks like natural language processing, audio transcription, and image generation.
-
-The OpenAI Fine-tuning connector offers APIs to connect and interact with the fine-tuning related endpoints of the OpenAI REST API, allowing users to customize OpenAI's AI models to meet specific needs.
+The `openai.finetunes` module is a direct, fully-typed REST connector for OpenAI's [Fine-tuning](https://platform.openai.com/docs/api-reference/fine-tuning) and Files APIs. Use it as a standalone client to upload training files and to create, monitor, and manage fine-tuning jobs that customize OpenAI models, independent of the `ballerina/ai` agent framework.
 
 ### Key Features
 - Create and manage fine-tuning jobs for custom model training


### PR DESCRIPTION
### Purpose

The first paragraph of the package Overview is what Ballerina Central stores as the package **summary**, and that summary is the `description` the Ballerina Copilot **library-search tool** returns to the agent when it selects a library. Across the OpenAI / Azure OpenAI / `ai.*` packages this first paragraph was a generic vendor blurb, so their summaries were nearly identical and an agent could not reliably tell them apart (e.g. an agent-framework model provider vs a direct REST connector).

### Change

Rewrite the Overview's first paragraph into a single, **capability-first** sentence that states what this module uniquely is — grounded in its actual API and `Ballerina.toml` type keywords — so the summary alone disambiguates it from its siblings. The now-redundant generic second paragraph is merged away. **Key Features** and everything below are untouched; `Module.md` is synced where present.

> Draft: opening for wording review. Part of a coordinated pass to disambiguate the AI/LLM package summaries surfaced by Copilot library search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)